### PR TITLE
Add notifyTomorrowTasks function

### DIFF
--- a/notifyTomorrowTasks.gs
+++ b/notifyTomorrowTasks.gs
@@ -1,0 +1,27 @@
+function notifyTomorrowTasks() {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Tasks');
+  if (!sheet) {
+    Logger.log('Sheet "Tasks" not found.');
+    return;
+  }
+  var values = sheet.getDataRange().getValues();
+  var today = new Date();
+  var tomorrow = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+  var tz = Session.getScriptTimeZone();
+  var tomorrowStr = Utilities.formatDate(tomorrow, tz, 'yyyy-MM-dd');
+  var tasks = [];
+  for (var i = 1; i < values.length; i++) { // Assuming row 1 is header
+    var taskName = values[i][0];
+    var dueDateStr = values[i][1];
+    var status = values[i][2];
+    if (dueDateStr === tomorrowStr && status === '未完了') {
+      tasks.push(taskName + '（期限: ' + dueDateStr + '）');
+    }
+  }
+  if (tasks.length > 0) {
+    var body = '以下のタスクが明日締切です:\n\n' + tasks.join('\n');
+    var email = Session.getActiveUser().getEmail();
+    MailApp.sendEmail(email, '明日締切のタスク通知', body);
+  }
+  Logger.log('通知対象タスク数: ' + tasks.length);
+}


### PR DESCRIPTION
## Summary
- implement Google Apps Script function `notifyTomorrowTasks` that checks tomorrow's tasks and emails them to the active user

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68501fafab5c8326bc8a80238afe78cb